### PR TITLE
Новый класс для URL паттернов

### DIFF
--- a/hw/code/utils/re_url.py
+++ b/hw/code/utils/re_url.py
@@ -1,0 +1,20 @@
+import re
+
+class RegExpUrl(object):
+
+    def __init__(self, url_pattern: str) -> None:
+        self.__expr = re.compile(url_pattern)
+        self.__url_pattern = url_pattern
+
+    @property
+    def url_pattern(self):
+        return self.__url_pattern
+
+    def __eq__(self, value: object, /) -> bool:
+        if isinstance(value, RegExpUrl):
+            return self.__expr == value.__expr
+        if isinstance(value, str):
+            result = self.__expr.match(value)
+            return result is not None
+        return False
+


### PR DESCRIPTION
Добавил класс, позволяющий ставить сайтам URL по регулярному выражению.

Протестировал на селениум тесте (который не вошел в коммит и не войдет), работает, не умерло.

При этом для генерации конкретного урла предлагаю добавлять в класс страницы следующий метод
![image](https://github.com/user-attachments/assets/deb3deb8-50f6-4664-95c6-a0ba6efa6e0d)

Нужно это, чтобы в тест не утекал URL:
![image](https://github.com/user-attachments/assets/45a396a3-ae30-4519-9c17-dd33d07fac97)
