### PR TITLE
Сохранение сессий в файлах

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 .env
 pyproject.toml
 uv.*
+*.json

--- a/hw/code/base_case.py
+++ b/hw/code/base_case.py
@@ -31,15 +31,11 @@ class BaseCase:
         if self.user is not None:
             # We need to login
             session = self.__extract_session(request)
-            if request.getfixturevalue('load_session_from_file'):
-                session = self.__read_session_from_file()
-                
             if session['cookie'] is None or session['local_storage'] is None:
                 user_id = self.__get_user_id(request)
                 self.__login(user_id)
                 session['cookie'] = self.driver.get_cookies()
                 session['local_storage'] = get_all_local_storage(self.driver)
-                self.__write_session_to_file(session['cookie'], session['local_storage'])
             else:
                 for cookie in session['cookie']:
                     self.driver.add_cookie(cookie)
@@ -73,13 +69,3 @@ class BaseCase:
             return request.getfixturevalue('advertiser_id')
         return request.getfixturevalue('partner_id')
     
-    def __read_session_from_file(self):
-        if self.user == UserType.ADVERTISER:
-            return read_session_from_file('advertiser_session.json')
-        return read_session_from_file('partner_session.json')
-    
-    def __write_session_to_file(self, cookies, local_storage):
-        if self.user == UserType.ADVERTISER:
-            write_session_to_file(cookies, local_storage, 'advertiser_session.json')
-        else:
-            write_session_to_file(cookies, local_storage, 'partner_session.json')

--- a/hw/code/base_case.py
+++ b/hw/code/base_case.py
@@ -13,6 +13,8 @@ from utils.local_storage import (get_all_local_storage,
 )
 from selenium.webdriver.chrome.webdriver import WebDriver
 
+from utils.save_session import read_session_from_file, write_session_to_file
+
 class UserType(enum.IntEnum):
     ADVERTISER = 1
     PARTNER = 2
@@ -29,11 +31,15 @@ class BaseCase:
         if self.user is not None:
             # We need to login
             session = self.__extract_session(request)
+            if request.getfixturevalue('load_session_from_file'):
+                session = self.__read_session_from_file()
+                
             if session['cookie'] is None or session['local_storage'] is None:
                 user_id = self.__get_user_id(request)
                 self.__login(user_id)
                 session['cookie'] = self.driver.get_cookies()
                 session['local_storage'] = get_all_local_storage(self.driver)
+                self.__write_session_to_file(session['cookie'], session['local_storage'])
             else:
                 for cookie in session['cookie']:
                     self.driver.add_cookie(cookie)
@@ -66,3 +72,14 @@ class BaseCase:
         if self.user == UserType.ADVERTISER:
             return request.getfixturevalue('advertiser_id')
         return request.getfixturevalue('partner_id')
+    
+    def __read_session_from_file(self):
+        if self.user == UserType.ADVERTISER:
+            return read_session_from_file('advertiser_session.json')
+        return read_session_from_file('partner_session.json')
+    
+    def __write_session_to_file(self, cookies, local_storage):
+        if self.user == UserType.ADVERTISER:
+            write_session_to_file(cookies, local_storage, 'advertiser_session.json')
+        else:
+            write_session_to_file(cookies, local_storage, 'partner_session.json')

--- a/hw/code/conftest.py
+++ b/hw/code/conftest.py
@@ -1,8 +1,9 @@
-from typing import Dict, List, Optional, Tuple, TypedDict
+from typing import Tuple
 from ui.fixtures import *
 import pytest
 import dotenv
 import os
+from utils.save_session import Session, read_session_from_file, write_session_to_file
 
 def pytest_addoption(parser):
     parser.addoption('--browser', default='chrome')
@@ -80,26 +81,27 @@ def advertiser_credentials() -> Tuple[str, str]:
         password
     )
 
-class Session(TypedDict):
-    cookie: Optional[List[Dict[str, str]]]
-    local_storage: Optional[Dict[str, str]]
-
 @pytest.fixture(scope='session')
-def load_session_from_file(config) -> bool:
-    return config['save_session']
-
-@pytest.fixture(scope='session')
-def partner_session() -> Session:
+def partner_session(config):
     # Login code is responsible for filling this list
-    return {
-        'cookie': None,
-        'local_storage': None
-    }
+    session = Session(cookie=None, local_storage=None)
+    if config['save_session']:
+        session_from_file = read_session_from_file('partner_session.json')
+        if session_from_file is not None:
+            session = session_from_file
+    yield session
+    if config['save_session']:
+        write_session_to_file(session, 'partner_session.json')
+    
 
 @pytest.fixture(scope='session')
-def advertiser_session() -> Session:
+def advertiser_session(config):
     # Login code is responsible for filling this list
-    return {
-        'cookie': None,
-        'local_storage': None
-    }
+    session = Session(cookie=None, local_storage=None)
+    if config['save_session']:
+        session_from_file = read_session_from_file('advertiser_session.json')
+        if session_from_file is not None:
+            session = session_from_file
+    yield session
+    if config['save_session']:
+        write_session_to_file(session, 'advertiser_session.json')

--- a/hw/code/conftest.py
+++ b/hw/code/conftest.py
@@ -10,6 +10,7 @@ def pytest_addoption(parser):
     parser.addoption('--debug_log', action='store_true')
     parser.addoption('--selenoid', action='store_true')
     parser.addoption('--vnc', action='store_true')
+    parser.addoption('--save-session', action='store_true')
 
 @pytest.fixture(scope='session')
 def config(request):
@@ -25,6 +26,7 @@ def config(request):
     else:
         selenoid = None
         vnc = False
+    save_session = request.config.getoption('--save-session')
 
     dotenv.load_dotenv()
 
@@ -34,6 +36,7 @@ def config(request):
         'debug_log': debug_log,
         'selenoid': selenoid,
         'vnc': vnc,
+        'save_session': save_session
     }
 
 @pytest.fixture(scope='session')
@@ -80,6 +83,10 @@ def advertiser_credentials() -> Tuple[str, str]:
 class Session(TypedDict):
     cookie: Optional[List[Dict[str, str]]]
     local_storage: Optional[Dict[str, str]]
+
+@pytest.fixture(scope='session')
+def load_session_from_file(config) -> bool:
+    return config['save_session']
 
 @pytest.fixture(scope='session')
 def partner_session() -> Session:

--- a/hw/code/utils/save_session.py
+++ b/hw/code/utils/save_session.py
@@ -1,0 +1,16 @@
+import json
+
+def write_session_to_file(cookies, local_storage, filename='session.json'):
+    with open(filename, 'w') as f:
+        json.dump({'cookies': cookies, 'local_storage': local_storage}, f)
+
+def read_session_from_file(filename='session.json'):
+    try:
+        with open(filename, 'r') as f:
+            session = json.load(f)
+            return {
+                'cookie': session['cookies'],
+                'local_storage': session['local_storage']
+            }
+    except FileNotFoundError:
+        return None

--- a/hw/code/utils/save_session.py
+++ b/hw/code/utils/save_session.py
@@ -1,16 +1,26 @@
 import json
+from typing import Optional, Dict, List, TypedDict
 
-def write_session_to_file(cookies, local_storage, filename='session.json'):
+class Session(TypedDict):
+    cookie: Optional[List[Dict[str, str]]]
+    local_storage: Optional[Dict[str, str]]
+
+def write_session_to_file(session: Session, filename='session.json'):
     with open(filename, 'w') as f:
-        json.dump({'cookies': cookies, 'local_storage': local_storage}, f)
+        json.dump(
+            {
+                'cookie': session['cookie'],
+                'local_storage': session['local_storage']
+            }, f
+        )
 
-def read_session_from_file(filename='session.json'):
+def read_session_from_file(filename='session.json') -> Optional[Session]:
     try:
         with open(filename, 'r') as f:
             session = json.load(f)
-            return {
-                'cookie': session['cookies'],
-                'local_storage': session['local_storage']
-            }
+            return Session(
+                cookie=session['cookie'],
+                local_storage=session['local_storage']
+            )
     except FileNotFoundError:
         return None


### PR DESCRIPTION
Короче, работает, но как оно сделано мне не очень нравится.
Так что @Regikon, посоветуй как следует нормально с фикстурами сделать, либо сам пофикси

Идея в том, что при вызове тестов `pytest --save-session hw/code`, используется сессия, сохранённая в файл на компьютере. 